### PR TITLE
Add `launchFromLara` param if launched from launch btn

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -228,11 +228,11 @@ class DocumentsController < ApplicationController
 
     if launch_params[:recordid] || (launch_params[:owner] && (launch_params[:recordname] || launch_params[:doc]))
       original_doc = find_doc_via_params(launch_params)
-      @master_document_url = codap_link(@codap_server, original_doc) if original_doc
+      @master_document_url = codap_link(@codap_server, original_doc, false, true) if original_doc
     elsif launch_params[:moreGames]
       moreGames = launch_params[:moreGames]
       moreGames = moreGames.to_json if moreGames.is_a?(Hash) || moreGames.is_a?(Array)
-      @master_document_url = codap_link(@codap_server, moreGames)
+      @master_document_url = codap_link(@codap_server, moreGames, false, true)
     end
 
     @buttonText = launch_params[:buttonText] || 'Launch'

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,5 +1,5 @@
 module DocumentsHelper
-  def codap_link(codap_server, document, runAsGuest=false)
+  def codap_link(codap_server, document, runAsGuest=false, fromLaunchPage=false)
     data = {
       "documentServer" => root_url(protocol: 'https')
     }
@@ -11,6 +11,7 @@ module DocumentsHelper
       data["moreGames"] = document
     end
     data["runAsGuest"] = 'true' if runAsGuest
+    data["launchFromLara"] = 'true' if fromLaunchPage
 
     url = Addressable::URI.parse(codap_server || ENV['CODAP_DEFAULT_URL'] || 'https://codap.concord.org/releases/latest/')
     new_query = url.query_values || {}

--- a/app/views/documents/launch.html.haml
+++ b/app/views/documents/launch.html.haml
@@ -6,7 +6,7 @@
     .row
       .small-12.text-center.columns
         - most_recent = @supplemental_documents.sort_by{|d| d.updated_at }.last
-        = link_to h(@buttonText), codap_link(@codap_server, most_recent), class: :"launch-button", target: "_blank"
+        = link_to h(@buttonText), codap_link(@codap_server, most_recent, false, true), class: :"launch-button", target: "_blank"
     .row.more-space-above
       .small-12.text-center.columns
         = link_to 'Reset to Original', @master_document_url, class: :"original-reset", target: "_blank"

--- a/spec/features/documents/codap_api_spec.rb
+++ b/spec/features/documents/codap_api_spec.rb
@@ -567,19 +567,19 @@ feature 'Document', :codap do
         doc  = FactoryGirl.create(:document, title: "something", shared: true, owner_id: user.id, form_content: '{ "foo": "bar" }')
         visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=foo']"
       end
       scenario 'user can launch a document via owner and doc' do
         user = FactoryGirl.create(:user, username: 'test2')
         doc  = FactoryGirl.create(:document, title: "something2", shared: true, owner_id: user.id, form_content: '{ "foo": "bar" }')
         visit '/document/launch?owner=test2&doc=something2&server=http://foo.com/'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=foo']"
       end
       scenario 'user can launch a document via moreGames' do
         visit '/document/launch?server=http://foo.com/&moreGames=%5B%7B%7D%5D'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=foo']"
       end
       scenario 'user can be logged in to launch' do
         # really, the requirement is that we don't need to be logged in, but that's already tested above,
@@ -590,7 +590,7 @@ feature 'Document', :codap do
         signin(user2.email, user2.password)
         visit '/document/launch?owner=test2&recordname=something2&server=http://foo.com/'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=foo']"
       end
       scenario 'the document needs to exist to launch' do
         r = SecureRandom.hex
@@ -605,7 +605,7 @@ feature 'Document', :codap do
             doc  = FactoryGirl.create(:document, title: "something", shared: true, owner_id: user.id, form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&runKey=bar&server=http://foo.com/'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
           end
           scenario 'also has a single document that matches the run key, a link to it is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -613,8 +613,8 @@ feature 'Document', :codap do
             doc2  = FactoryGirl.create(:document, title: "something", shared: false, owner_id: nil, run_key: 'bar', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&runKey=bar&server=http://foo.com/'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector  "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector  "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'also has multiple documents that match the run key, a link to each of them is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -625,8 +625,8 @@ feature 'Document', :codap do
             doc5  = FactoryGirl.create(:document, title: "something5", shared: false, owner_id: nil, run_key: 'bar', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc5.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc5.id}&runKey=bar']"
           end
           scenario 'also has documents that do not match the run key, a link to each of them is not also displayed' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -637,21 +637,21 @@ feature 'Document', :codap do
             doc5  = FactoryGirl.create(:document, title: "something5", shared: false, owner_id: nil, run_key: 'baz', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc3.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc3.id}&runKey=bar']"
           end
           scenario 'moreGames in url and no documents with run key, only a link to the moregames url is present' do
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=bar']"
           end
           scenario 'moreGames in url and one document with run key, 2 links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
             doc2  = FactoryGirl.create(:document, title: "something", shared: false, owner_id: nil, run_key: 'bar', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'moreGames in url and multiple documents with run key, all links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
@@ -661,8 +661,8 @@ feature 'Document', :codap do
             doc5  = FactoryGirl.create(:document, title: "something5", shared: false, owner_id: nil, run_key: 'baz', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc4.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc4.id}&runKey=bar']"
           end
         end
         describe 'logged in user' do
@@ -673,7 +673,7 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
           end
           scenario 'also has a single document that matches the run key, a link to it is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -683,8 +683,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'also has multiple documents that match the run key, a link to each of them is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -697,8 +697,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc5.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc5.id}&runKey=bar']"
           end
           scenario 'also has documents that do not match the run key, a link to each of them is not also displayed' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -711,15 +711,15 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc3.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc3.id}&runKey=bar']"
           end
           scenario 'moreGames in url and no documents with run key, only a link to the moregames url is present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
             signin(user4.email, user4.password)
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=bar']"
           end
           scenario 'moreGames in url and one document with run key, 2 links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
@@ -727,8 +727,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'moreGames in url and multiple documents with run key, all links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
@@ -739,8 +739,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc4.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc4.id}&runKey=bar']"
           end
         end
       end
@@ -759,7 +759,7 @@ feature 'Document', :codap do
           user2 = FactoryGirl.create(:user, username: 'test4')
           signin(user2.email, user2.password)
           visit '/document/launch?owner=test2&recordname=something2&server=http://foo.com/&auth_provider=http://bar.com/'
-          expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+          expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&launchFromLara=true&recordid=#{doc.id}&runKey=foo']"
         end
       end
       describe 'LARA integration' do

--- a/spec/features/documents/codap_api_spec.rb
+++ b/spec/features/documents/codap_api_spec.rb
@@ -567,19 +567,19 @@ feature 'Document', :codap do
         doc  = FactoryGirl.create(:document, title: "something", shared: true, owner_id: user.id, form_content: '{ "foo": "bar" }')
         visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
       end
       scenario 'user can launch a document via owner and doc' do
         user = FactoryGirl.create(:user, username: 'test2')
         doc  = FactoryGirl.create(:document, title: "something2", shared: true, owner_id: user.id, form_content: '{ "foo": "bar" }')
         visit '/document/launch?owner=test2&doc=something2&server=http://foo.com/'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
       end
       scenario 'user can launch a document via moreGames' do
         visit '/document/launch?server=http://foo.com/&moreGames=%5B%7B%7D%5D'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=foo']"
       end
       scenario 'user can be logged in to launch' do
         # really, the requirement is that we don't need to be logged in, but that's already tested above,
@@ -590,7 +590,7 @@ feature 'Document', :codap do
         signin(user2.email, user2.password)
         visit '/document/launch?owner=test2&recordname=something2&server=http://foo.com/'
         expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+        expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
       end
       scenario 'the document needs to exist to launch' do
         r = SecureRandom.hex
@@ -605,7 +605,7 @@ feature 'Document', :codap do
             doc  = FactoryGirl.create(:document, title: "something", shared: true, owner_id: user.id, form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&runKey=bar&server=http://foo.com/'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
           end
           scenario 'also has a single document that matches the run key, a link to it is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -613,8 +613,8 @@ feature 'Document', :codap do
             doc2  = FactoryGirl.create(:document, title: "something", shared: false, owner_id: nil, run_key: 'bar', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&runKey=bar&server=http://foo.com/'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector  "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector  "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'also has multiple documents that match the run key, a link to each of them is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -625,8 +625,8 @@ feature 'Document', :codap do
             doc5  = FactoryGirl.create(:document, title: "something5", shared: false, owner_id: nil, run_key: 'bar', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc5.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc5.id}&runKey=bar']"
           end
           scenario 'also has documents that do not match the run key, a link to each of them is not also displayed' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -637,21 +637,21 @@ feature 'Document', :codap do
             doc5  = FactoryGirl.create(:document, title: "something5", shared: false, owner_id: nil, run_key: 'baz', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc3.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc3.id}&runKey=bar']"
           end
           scenario 'moreGames in url and no documents with run key, only a link to the moregames url is present' do
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
           end
           scenario 'moreGames in url and one document with run key, 2 links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
             doc2  = FactoryGirl.create(:document, title: "something", shared: false, owner_id: nil, run_key: 'bar', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'moreGames in url and multiple documents with run key, all links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
@@ -661,8 +661,8 @@ feature 'Document', :codap do
             doc5  = FactoryGirl.create(:document, title: "something5", shared: false, owner_id: nil, run_key: 'baz', form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }')
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc4.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc4.id}&runKey=bar']"
           end
         end
         describe 'logged in user' do
@@ -673,7 +673,7 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
           end
           scenario 'also has a single document that matches the run key, a link to it is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -683,8 +683,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'also has multiple documents that match the run key, a link to each of them is displayed too' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -697,8 +697,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc5.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc5.id}&runKey=bar']"
           end
           scenario 'also has documents that do not match the run key, a link to each of them is not also displayed' do
             user = FactoryGirl.create(:user, username: 'test2')
@@ -711,15 +711,15 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?owner=test2&recordname=something&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc3.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc3.id}&runKey=bar']"
           end
           scenario 'moreGames in url and no documents with run key, only a link to the moregames url is present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
             signin(user4.email, user4.password)
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
           end
           scenario 'moreGames in url and one document with run key, 2 links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
@@ -727,8 +727,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc2.id}&runKey=bar']"
           end
           scenario 'moreGames in url and multiple documents with run key, all links are present' do
             user4 = FactoryGirl.create(:user, username: 'test4')
@@ -739,8 +739,8 @@ feature 'Document', :codap do
             signin(user4.email, user4.password)
             visit '/document/launch?moreGames=%5B%7B%7D%5D&server=http://foo.com/&runKey=bar'
             expect(page).to have_selector('.launch-button', count: 1)
-            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
-            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc4.id}&runKey=bar']"
+            expect(page).to have_selector "a.original-reset[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&moreGames=%5B%7B%7D%5D&runKey=bar']"
+            expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc4.id}&runKey=bar']"
           end
         end
       end
@@ -759,7 +759,7 @@ feature 'Document', :codap do
           user2 = FactoryGirl.create(:user, username: 'test4')
           signin(user2.email, user2.password)
           visit '/document/launch?owner=test2&recordname=something2&server=http://foo.com/&auth_provider=http://bar.com/'
-          expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=http%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
+          expect(page).to have_selector "a.launch-button[href='http://foo.com/?documentServer=https%3A%2F%2Fwww.example.com%2F&recordid=#{doc.id}&runKey=foo']"
         end
       end
       describe 'LARA integration' do
@@ -877,7 +877,7 @@ feature 'Document', :codap do
       let(:server)   { 'http://foo.com/' }
 
       scenario 'user needs to be logged in to view non-anonymous work' do
-        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
         expect(page).to have_content 'No documents have been saved!'
         signin(teacher.email, teacher.password)
@@ -886,8 +886,8 @@ feature 'Document', :codap do
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'user does not need to be logged in to view anonymous work' do
-        url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo', runAsGuest: 'true'})
-        url2 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo', runAsGuest: 'true'})
+        url2 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -921,21 +921,21 @@ feature 'Document', :codap do
       end
       scenario 'user can report a document via owner and recordname' do
         signin(teacher.email, teacher.password)
-        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'user can report a document via owner and doc' do
         signin(teacher.email, teacher.password)
-        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, doc: template.title, server: server, reportUser: student.username, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'user can report a document via recordid' do
         signin(teacher.email, teacher.password)
-        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordid: template.id, server: server, reportUser: student.username, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
@@ -947,8 +947,8 @@ feature 'Document', :codap do
       end
       scenario 'reportUser also has multiple documents that match the run key, a link to each of them is displayed too' do
         signin(teacher.email, teacher.password)
-        url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-        url2 = doc_url(server, {recordid: student_doc1b.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+        url2 = doc_url(server, {recordid: student_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 2)
         expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -956,11 +956,11 @@ feature 'Document', :codap do
       end
       scenario 'reportUser also has documents that do not match the run key, a link to each of them is not also displayed' do
         signin(teacher.email, teacher.password)
-        url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-        url2 = doc_url(server, {recordid: student_doc1b.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-        url3 = doc_url(server, {recordid: student_doc1c.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-        url4 = doc_url(server, {recordid: student_doc2a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-        url5 = doc_url(server, {recordid: student_doc2b.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+        url2 = doc_url(server, {recordid: student_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+        url3 = doc_url(server, {recordid: student_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+        url4 = doc_url(server, {recordid: student_doc2a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+        url5 = doc_url(server, {recordid: student_doc2b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 3)
         expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -969,15 +969,15 @@ feature 'Document', :codap do
       end
       scenario 'moreGames in url and one document with run key, 1 link is present' do
         signin(teacher.email, teacher.password)
-        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(server: server, moreGames: '[{}]', runKey: 'foo', reportUser: student.username)
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'moreGames in url and multiple documents with run key, all links are present' do
         signin(teacher.email, teacher.password)
-        url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-        url2 = doc_url(server, {recordid: student_doc1c.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+        url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+        url2 = doc_url(server, {recordid: student_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(server: server, moreGames: '[{}]', runKey: 'foo', reportUser: student.username)
         expect(page).to have_selector('.launch-button', count: 2)
         expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -986,21 +986,21 @@ feature 'Document', :codap do
       describe 'anonymous' do
         scenario 'user can report a document via owner and recordname' do
           signin(teacher.email, teacher.password)
-          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 1)
           expect(page).to have_selector "a.launch-button[href='#{url}']"
         end
         scenario 'user can report a document via owner and doc' do
           signin(teacher.email, teacher.password)
-          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(owner: author.username, doc: template.title, server: server, runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 1)
           expect(page).to have_selector "a.launch-button[href='#{url}']"
         end
         scenario 'user can report a document via recordid' do
           signin(teacher.email, teacher.password)
-          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(owner: author.username, recordid: template.id, server: server, runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 1)
           expect(page).to have_selector "a.launch-button[href='#{url}']"
@@ -1012,8 +1012,8 @@ feature 'Document', :codap do
         end
         scenario 'reportUser also has multiple documents that match the run key, a link to each of them is displayed too' do
           signin(teacher.email, teacher.password)
-          url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-          url2 = doc_url(server, {recordid: anon_doc1b.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+          url2 = doc_url(server, {recordid: anon_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 2)
           expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -1021,11 +1021,11 @@ feature 'Document', :codap do
         end
         scenario 'reportUser also has documents that do not match the run key, a link to each of them is not also displayed' do
           signin(teacher.email, teacher.password)
-          url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-          url2 = doc_url(server, {recordid: anon_doc1b.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-          url3 = doc_url(server, {recordid: anon_doc1c.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-          url4 = doc_url(server, {recordid: anon_doc2a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-          url5 = doc_url(server, {recordid: anon_doc2b.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+          url2 = doc_url(server, {recordid: anon_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+          url3 = doc_url(server, {recordid: anon_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+          url4 = doc_url(server, {recordid: anon_doc2a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+          url5 = doc_url(server, {recordid: anon_doc2b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 3)
           expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -1034,15 +1034,15 @@ feature 'Document', :codap do
         end
         scenario 'moreGames in url and one document with run key, 1 link is present' do
           signin(teacher.email, teacher.password)
-          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(server: server, moreGames: '[{}]', runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 1)
           expect(page).to have_selector "a.launch-button[href='#{url}']"
         end
         scenario 'moreGames in url and multiple documents with run key, all links are present' do
           signin(teacher.email, teacher.password)
-          url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
-          url2 = doc_url(server, {recordid: anon_doc1c.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
+          url2 = doc_url(server, {recordid: anon_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(server: server, moreGames: '[{}]', runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 2)
           expect(page).to have_selector "a.launch-button[href='#{url1}']"
@@ -1063,7 +1063,7 @@ feature 'Document', :codap do
         end
         scenario 'the user will not be authenticated if auth_provider is set and the user is logged in' do
           signin(teacher.email, teacher.password)
-          url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'http://www.example.com/', runKey: 'foo'})
+          url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
           visit report_path(auth_provider: 'http://bar.com', owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
           expect(page).to have_selector('.launch-button', count: 1)
           expect(page).to have_selector "a.launch-button[href='#{url}']"


### PR DESCRIPTION
This allows CODAP to know that this was launched from LARA. When we launch using the
launch button, which should only be used when embedded in LARA, we will add a query
parameter to the url, `?launchFromLara=true`

https://www.pivotaltracker.com/story/show/116548221

@scytacki Could you take a glance at this, and see if you think this is the best way to do this (no rush)?