### PR TITLE
Make report easier to integrate

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -285,19 +285,47 @@ class DocumentsController < ApplicationController
     elsif (num_users == 1)
       @reportUserId = users.first.id
     else
-      # Try to find a user that came from the same authentication source as we did
-      source = current_user.authentications.first.provider rescue nil
-      u = users.to_a.detect {|user| !user.authentications.detect {|a| a.provider == source }.nil? }
-      @reportUserId = u ? u.id : nil
+      # HACK: because usernames are not unique, just passing the username is not enough to find the user.
+      #  the username is taken from the authentication provider. It is common in testing to have the same
+      #  username on production and staging portals. So this problem happens often in testing. We do have
+      #  a runKey though, and it seems that is generally unique between portals, so it can be used to figure
+      #  out the correct user.
+      #
+      #  A better solution would be to enforce unique runKeys for each document, and then there would be no
+      #  need to lookup the user here. I think doing that would require defining the runKey only on the server
+      #  currently the runKey can be set by the client when a document is created.
+      unique_owner_docs = Document.select(:owner_id).where(owner_id: users.map(&:id), run_key: @runKey).group(:owner_id)
+      owners = unique_owner_docs.map{|doc| doc.owner}
+
+      if owners.count == 1
+        @reportUserId = owners.first.id
+      else
+        # either there are no documents matching any of these users with the pass runkey
+        # or there are mutliple users that have documents with the same runkey
+        # if there are no documents then we fall back to initial users list, otherwise
+        # we now look at just the owners of the documents.
+        if owners.count > 1
+          users = owners
+        end
+
+        # As a last resort for filtering out multiple users, try to filter the users based on the authentication
+        # of the current_user.  When running the report the current_user will probably be the teacher. And in
+        # the majority cases the teacher will only have one authentication provider, so this is a good filter.
+        # However for test teachers it is very likely the teacher will have multiple authentications so in that
+        # case this probably isn't going to filter very much.
+        source = current_user.authentications.first.provider rescue nil
+        u = users.to_a.detect {|user| !user.authentications.detect {|a| a.provider == source }.nil? }
+        @reportUserId = u ? u.id : nil
+      end
     end
 
+    # It isn't entirely clear why we need to find the master document
+    # The report view has different messages if we do or don't
     if report_params[:recordid] || (report_params[:owner] && (report_params[:recordname] || report_params[:doc]))
       original_doc = find_doc_via_params(report_params)
-      @master_document_url = codap_link(@codap_server, original_doc) if original_doc
+      @found_master_document = original_doc.present?
     elsif report_params[:moreGames]
-      moreGames = report_params[:moreGames]
-      moreGames = moreGames.to_json if moreGames.is_a?(Hash) || moreGames.is_a?(Array)
-      @master_document_url = codap_link(@codap_server, moreGames)
+      @found_master_document = true
     end
 
     @supplemental_documents = Document.where(owner_id: @reportUserId, run_key: @runKey, is_codap_main_document: true)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,6 +13,18 @@ class Ability
       !user.nil? || !extra[:runKey].blank?
     end
 
+    if extra[:runKey]
+      # anyone can view reports if they know the runKey
+      can [:report], Document do |doc|
+        doc.nil? || (doc.run_key.present? && doc.run_key == extra[:runKey])
+      end
+
+      # anyone can open a document if they know the runKey
+      can [:open], Document do |doc|
+        doc.run_key.present? && doc.run_key == extra[:runKey]
+      end
+    end
+
     if user
       # Stuff logged in people can do
 
@@ -20,7 +32,7 @@ class Ability
       can [:index, :list, :create, :new, :all], Document
 
       # read a doc
-      can [:read, :show, :open, :report], Document do |doc|
+      can [:read, :show, :open], Document do |doc|
           doc.owner == user || (doc.run_key.present? && doc.run_key == extra[:runKey])
       end
 
@@ -30,17 +42,16 @@ class Ability
       end
 
       # User
-      can [:read, :update, :info, :authenticate, :report], User do |u|
+      can [:read, :update, :info, :authenticate], User do |u|
         u == user
       end
     else
       # anonymous gets read/write access to documents if they know the documents run_key
       if extra[:runKey]
         can [:index, :list, :all], Document
-        can [:read, :show, :edit, :update, :destroy, :save, :open, :open_original, :report], Document do |doc|
+        can [:read, :show, :edit, :update, :destroy, :save, :open, :open_original], Document do |doc|
             doc.owner.nil? && doc.run_key.present? && doc.run_key == extra[:runKey]
         end
-        can [:report], :nil_user
       end
       # anonymous can't do anything else
     end

--- a/app/views/documents/report.html.haml
+++ b/app/views/documents/report.html.haml
@@ -1,4 +1,4 @@
--if @master_document_url
+-if @found_master_document
   - if @supplemental_documents && @supplemental_documents.size > 0
     - sorted_docs = @supplemental_documents.sort_by{|d| d.updated_at }.reverse
     .row

--- a/spec/features/documents/codap_api_spec.rb
+++ b/spec/features/documents/codap_api_spec.rb
@@ -261,11 +261,11 @@ feature 'Document', :codap do
           expect(page).to have_content %!{"valid":false,"message":"error.notFound"}!
         end
 
-        scenario 'anonymous user can not open a document owned by another person even with the correct run_key' do
+        scenario 'anonymous user can open a non-shared document owned by someone else with the correct run_key' do
           user2 = FactoryGirl.create(:user, username: 'test2', email: 'test2@email.com')
           doc2 = FactoryGirl.create(:document, title: "test2 doc", shared: false, owner_id: user2.id, run_key: 'run2', form_content: '{ "foo": "bar" }')
           visit '/document/open?runKey=run2&owner=test2&recordname=test2%20doc'
-          expect(page).to have_content %!{"valid":false,"message":"error.permissions"}!
+          expect(page).to have_content %!{"foo":"bar"}!
         end
 
         scenario 'logged in user can open a non-shared document owned by anonymous with the correct run key' do

--- a/spec/features/documents/report_spec.rb
+++ b/spec/features/documents/report_spec.rb
@@ -12,7 +12,6 @@ feature 'Document', :codap do
       user = FactoryGirl.build(:user, username: 'dup-student', email: 'dup.student2@example.com')
       user.save(validate: false)
       user }
-    let(:teacher)  { FactoryGirl.create(:user, username: 'teacher') }
     let(:template) { FactoryGirl.create(:document,
       title: "template", shared: true, owner_id: author.id,
       form_content: '{ "foo": "bar", "appName": "name", "appVersion": "version", "appBuildNum": 1 }') }
@@ -74,35 +73,13 @@ feature 'Document', :codap do
       run_key: 'bar') }
     let(:server)   { 'http://foo.com/' }
 
-    scenario 'user needs to be logged in to view non-anonymous work' do
-      url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
-      visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
-      expect(page).to have_content 'No documents have been saved!'
-      signin(teacher.email, teacher.password)
-      visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
-      expect(page).to have_selector('.launch-button', count: 1)
-      expect(page).to have_selector "a.launch-button[href='#{url}']"
-    end
-    scenario 'user does not need to be logged in to view anonymous work' do
-      url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo', runAsGuest: 'true'})
-      url2 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
-      visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
-      expect(page).to have_selector('.launch-button', count: 1)
-      expect(page).to have_selector "a.launch-button[href='#{url1}']"
-      signin(teacher.email, teacher.password)
-      visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
-      expect(page).to have_selector('.launch-button', count: 1)
-      expect(page).to have_selector "a.launch-button[href='#{url2}']"
-    end
     scenario 'the template document needs to exist' do
-      signin(teacher.email, teacher.password)
       visit report_path(owner: author.username, recordname: template.title + "2", server: server, reportUser: student.username, runKey: 'foo')
       expect(page).to have_content "Error: The requested document could not be found."
       visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
       expect(page).to have_content 'No documents have been saved!'
     end
     scenario 'runKey needs to be provided' do
-      signin(teacher.email, teacher.password)
       expect {
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username)
       }.to raise_error(ActiveRecord::RecordNotFound)
@@ -110,7 +87,6 @@ feature 'Document', :codap do
       expect(page).to have_content 'No documents have been saved!'
     end
     scenario 'server needs to be provided' do
-      signin(teacher.email, teacher.password)
       expect {
         visit report_path(owner: author.username, recordname: template.title, reportUser: student.username, runKey: 'foo')
       }.to raise_error(ActiveRecord::RecordNotFound)
@@ -118,33 +94,28 @@ feature 'Document', :codap do
       expect(page).to have_content 'No documents have been saved!'
     end
     scenario 'user can report a document via owner and recordname' do
-      signin(teacher.email, teacher.password)
       url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
       expect(page).to have_selector('.launch-button', count: 1)
       expect(page).to have_selector "a.launch-button[href='#{url}']"
     end
     scenario 'user can report a document via owner and doc' do
-      signin(teacher.email, teacher.password)
       url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       visit report_path(owner: author.username, doc: template.title, server: server, reportUser: student.username, runKey: 'foo')
       expect(page).to have_selector('.launch-button', count: 1)
       expect(page).to have_selector "a.launch-button[href='#{url}']"
     end
     scenario 'user can report a document via recordid' do
-      signin(teacher.email, teacher.password)
       url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       visit report_path(owner: author.username, recordid: template.id, server: server, reportUser: student.username, runKey: 'foo')
       expect(page).to have_selector('.launch-button', count: 1)
       expect(page).to have_selector "a.launch-button[href='#{url}']"
     end
     scenario 'user can report a document via moreGames' do
-      signin(teacher.email, teacher.password)
       visit report_path(server: server, moreGames: '[{}]', runKey: 'foo', reportUser: student.username)
       expect(page).to have_content 'No documents have been saved!'
     end
     scenario 'reportUser also has multiple documents that match the run key, a link to each of them is displayed too' do
-      signin(teacher.email, teacher.password)
       url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       url2 = doc_url(server, {recordid: student_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
@@ -153,7 +124,6 @@ feature 'Document', :codap do
       expect(page).to have_selector "a.launch-button[href='#{url2}']"
     end
     scenario 'reportUser also has documents that do not match the run key, a link to each of them is not also displayed' do
-      signin(teacher.email, teacher.password)
       url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       url2 = doc_url(server, {recordid: student_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       url3 = doc_url(server, {recordid: student_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
@@ -167,7 +137,6 @@ feature 'Document', :codap do
     end
     describe 'multiple users with the same username' do
       scenario 'report should show report for "bar" runKey' do
-        signin(teacher.email, teacher.password)
         url1 = doc_url(server, {recordid: dup_student1_doc.id, documentServer: 'https://www.example.com/', runKey: 'bar'})
         url2 = doc_url(server, {recordid: dup_student2_doc.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: dup_student1.username, runKey: 'bar')
@@ -175,7 +144,6 @@ feature 'Document', :codap do
         expect(page).to have_selector "a.launch-button[href='#{url1}']"
       end
       scenario 'report should show report for "foo" runKey' do
-        signin(teacher.email, teacher.password)
         url1 = doc_url(server, {recordid: dup_student1_doc.id, documentServer: 'https://www.example.com/', runKey: 'bar'})
         url2 = doc_url(server, {recordid: dup_student2_doc.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: dup_student2.username, runKey: 'foo')
@@ -184,14 +152,12 @@ feature 'Document', :codap do
       end
     end
     scenario 'moreGames in url and one document with run key, 1 link is present' do
-      signin(teacher.email, teacher.password)
       url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       visit report_path(server: server, moreGames: '[{}]', runKey: 'foo', reportUser: student.username)
       expect(page).to have_selector('.launch-button', count: 1)
       expect(page).to have_selector "a.launch-button[href='#{url}']"
     end
     scenario 'moreGames in url and multiple documents with run key, all links are present' do
-      signin(teacher.email, teacher.password)
       url1 = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       url2 = doc_url(server, {recordid: student_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
       visit report_path(server: server, moreGames: '[{}]', runKey: 'foo', reportUser: student.username)
@@ -201,33 +167,28 @@ feature 'Document', :codap do
     end
     describe 'anonymous' do
       scenario 'user can report a document via owner and recordname' do
-        signin(teacher.email, teacher.password)
         url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'user can report a document via owner and doc' do
-        signin(teacher.email, teacher.password)
         url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, doc: template.title, server: server, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'user can report a document via recordid' do
-        signin(teacher.email, teacher.password)
         url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordid: template.id, server: server, runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'user can report a document via moreGames' do
-        signin(teacher.email, teacher.password)
         visit report_path(server: server, moreGames: '[{}]', runKey: 'foo')
         expect(page).to have_content 'No documents have been saved!'
       end
       scenario 'reportUser also has multiple documents that match the run key, a link to each of them is displayed too' do
-        signin(teacher.email, teacher.password)
         url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         url2 = doc_url(server, {recordid: anon_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(owner: author.username, recordname: template.title, server: server, runKey: 'foo')
@@ -236,7 +197,6 @@ feature 'Document', :codap do
         expect(page).to have_selector "a.launch-button[href='#{url2}']"
       end
       scenario 'reportUser also has documents that do not match the run key, a link to each of them is not also displayed' do
-        signin(teacher.email, teacher.password)
         url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         url2 = doc_url(server, {recordid: anon_doc1b.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         url3 = doc_url(server, {recordid: anon_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
@@ -249,40 +209,18 @@ feature 'Document', :codap do
         expect(page).to have_selector "a.launch-button[href='#{url3}']"
       end
       scenario 'moreGames in url and one document with run key, 1 link is present' do
-        signin(teacher.email, teacher.password)
         url = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(server: server, moreGames: '[{}]', runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 1)
         expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
       scenario 'moreGames in url and multiple documents with run key, all links are present' do
-        signin(teacher.email, teacher.password)
         url1 = doc_url(server, {recordid: anon_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         url2 = doc_url(server, {recordid: anon_doc1c.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
         visit report_path(server: server, moreGames: '[{}]', runKey: 'foo')
         expect(page).to have_selector('.launch-button', count: 2)
         expect(page).to have_selector "a.launch-button[href='#{url1}']"
         expect(page).to have_selector "a.launch-button[href='#{url2}']"
-      end
-    end
-    describe 'auto authentication' do
-      scenario 'the user will not be authenticated if auth_provider is set and the user is not logged in' do
-        visit report_path(auth_provider: 'http://bar.com', owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
-        expect(page).to have_content 'No documents have been saved!'
-      end
-      scenario 'the user will be authenticated if referrer is set and the user is not logged in' do
-        Capybara.current_session.driver.header 'Referer', 'http://bar.com/portal/offerings/1/report'
-        expect {
-          visit report_path(owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
-        }.to raise_error(ActionController::RoutingError) # capybara doesn't handle the redirects well
-        expect(page.current_url).to match 'http://bar.com/auth/concord_id/authorize'
-      end
-      scenario 'the user will not be authenticated if auth_provider is set and the user is logged in' do
-        signin(teacher.email, teacher.password)
-        url = doc_url(server, {recordid: student_doc1a.id, documentServer: 'https://www.example.com/', runKey: 'foo'})
-        visit report_path(auth_provider: 'http://bar.com', owner: author.username, recordname: template.title, server: server, reportUser: student.username, runKey: 'foo')
-        expect(page).to have_selector('.launch-button', count: 1)
-        expect(page).to have_selector "a.launch-button[href='#{url}']"
       end
     end
   end

--- a/spec/support/helpers/url_helpers.rb
+++ b/spec/support/helpers/url_helpers.rb
@@ -20,6 +20,7 @@ module Features
 
     def doc_url(base, query_hash)
       uri = Addressable::URI.parse(base)
+      query_hash[:runAsGuest] = 'true'
       uri.query_values = (uri.query_values(Hash) || {}).merge(query_hash)
       uri.to_s
     end


### PR DESCRIPTION
This PR removes authentication from the report link. It also now allows anonymous users to open documents that are owned by someone else as long as those documents have a run_key.

Additionally it improves the searching and filtering done when trying to find the correct set of documents for the report. Previous if there were multiple users with the same username the report would not use the run_key to find the correct set of documents. 

Ideally we'd enforce run_key uniqueness so then the username could be dropped entirely. But that is too big of a change to make right now.

I'm not sure who should look at this. Perhaps @sfentress and/or @knowuh ?