### PR TITLE
WIP: Add access time logging

### DIFF
--- a/app/controllers/documents_v2_controller.rb
+++ b/app/controllers/documents_v2_controller.rb
@@ -8,45 +8,47 @@ class DocumentsV2Controller < ApplicationController
   # v2 of the api is all anonymous access
   skip_authorization_check
 
+  after_filter :log_access, :only => [:open, :save, :patch, :copy_shared]
+
   include DocumentsV2Helper
 
   def open
-    document = Document.find_by(id: params[:id])
-    render_not_found && return unless document
+    @document = Document.find_by(id: params[:id])
+    render_not_found && return unless @document
 
     access_key = parse_access_key
 
     # If an access key is present it must be checked. Shared documents without access keys are ok, unshared documents need to have a valid access key of either type.
-    if access_key || !document.shared
+    if access_key || !@document.shared
       render_missing_param("accessKey") && return unless access_key
       render_invalid_access_key_format && return unless access_key.valid_format?
-      render_invalid_access_key && return unless valid_document_access_key(document, access_key)
+      render_invalid_access_key && return unless valid_document_access_key(access_key)
     end
 
     read_only = !access_key || access_key.read_only?
     response.headers['Allow'] = "GET, HEAD, OPTIONS#{read_only ? '' : ', PUT, PATCH'}"
-    render json: document.content
+    render json: @document.content
   end
 
   def save
-    document = Document.find_by(id: params[:id])
-    render_not_found && return unless document
+    @document = Document.find_by(id: params[:id])
+    render_not_found && return unless @document
 
-    return unless require_valid_read_write_access_key(document)
+    return unless require_valid_read_write_access_key
 
-    document.form_content = request.raw_post
-    if document.save
-      render json: {status: "Saved", valid: true, id: document.id }, status: 200
+    @document.form_content = request.raw_post
+    if @document.save
+      render json: {status: "Saved", valid: true, id: @document.id }, status: 200
     else
-      render json: {status: "Error", errors: document.errors.full_messages, valid: false, message: 'error.writeFailed' }, status: 400
+      render json: {status: "Error", errors: @document.errors.full_messages, valid: false, message: 'error.writeFailed' }, status: 400
     end
   end
 
   def patch
-    document = Document.find_by(id: params[:id])
-    render_not_found && return unless document
+    @document = Document.find_by(id: params[:id])
+    render_not_found && return unless @document
 
-    return unless require_valid_read_write_access_key(document)
+    return unless require_valid_read_write_access_key
 
     begin
       patchset = JSON.parse(request.raw_post)
@@ -57,11 +59,11 @@ class DocumentsV2Controller < ApplicationController
     end
 
     begin
-      patchedContent = JSON::Patch.new(document.content, patchset).call
-      if document.update_columns({updated_at: Time.current}) && document.contents.update_columns({content: patchedContent, updated_at: Time.current})
-        render json: {status: "Patched", valid: true, id: document.id}, status: 200
+      patchedContent = JSON::Patch.new(@document.content, patchset).call
+      if @document.update_columns({updated_at: Time.current}) && @document.contents.update_columns({content: patchedContent, updated_at: Time.current})
+        render json: {status: "Patched", valid: true, id: @document.id}, status: 200
       else
-        render json: {status: "Error", errors: document.errors.full_messages + document.contents.errors.full_messages, valid: false, message: 'error.writeFailed' }, status: 400
+        render json: {status: "Error", errors: @document.errors.full_messages + @document.contents.errors.full_messages, valid: false, message: 'error.writeFailed' }, status: 400
       end
     rescue => e
       render json: {status: "Error", errors: ["Invalid patch JSON (executing)", e.to_s], valid: false, message: 'error.writeFailed' }, status: 400
@@ -71,10 +73,10 @@ class DocumentsV2Controller < ApplicationController
   def copy_shared
     render_missing_param("source") && return unless params[:source].present?
 
-    document = Document.find_by(id: params[:source])
-    render_not_found && return unless document
+    @document = Document.find_by(id: params[:source])
+    render_not_found && return unless @document
 
-    if document.shared
+    if @document.shared
       # generate two unique new access keys - we can't use a unique index constraint because the keys will be null for older documents
       # giving the length of the random strings this will probably never loop
       read_access_key = nil
@@ -86,9 +88,9 @@ class DocumentsV2Controller < ApplicationController
       end
 
       copy = Document.new
-      copy.title = document.title
-      copy.content = document.content
-      copy.original_content = document.content
+      copy.title = @document.title
+      copy.content = @document.content
+      copy.original_content = @document.content
       copy.read_access_key = read_access_key
       copy.read_write_access_key = read_write_access_key
       copy.run_key = read_write_access_key  # the run_key needs to be set because of the title validation: "validates :title, uniqueness: {scope: [:owner, :run_key]}"
@@ -133,23 +135,27 @@ class DocumentsV2Controller < ApplicationController
     end
   end
 
-  def valid_document_access_key(document, access_key)
+  def valid_document_access_key(access_key)
     if access_key.read_only?
-      document.read_access_key == access_key.key
+      @document.read_access_key == access_key.key
     elsif access_key.read_write?
-      document.read_write_access_key == access_key.key
+      @document.read_write_access_key == access_key.key
     else
       false
     end
   end
 
-  def require_valid_read_write_access_key(document)
+  def require_valid_read_write_access_key
     access_key = parse_access_key
     render_missing_param("accessKey") && return unless access_key
     render_invalid_access_key_format && return unless access_key.valid_format?
     render_invalid_access_key_type && return unless access_key.read_write?
-    render_invalid_access_key && return unless valid_document_access_key(document, access_key)
+    render_invalid_access_key && return unless valid_document_access_key(access_key)
     access_key
+  end
+
+  def log_access
+    DocumentAccessLog.log(@document.id, '2', action_name, {id: params[:id]}.to_json) if @document
   end
 
 end

--- a/app/models/document_access_log.rb
+++ b/app/models/document_access_log.rb
@@ -1,0 +1,18 @@
+class DocumentAccessLog < ActiveRecord::Base
+  self.table_name = "document_access_log"
+
+  before_save :generate_timestamp
+
+  def self.log(document_id, api_version, action, access_params)
+    entry = DocumentAccessLog.new
+    entry.document_id = document_id
+    entry.action = action
+    entry.access_params = access_params
+    entry.api_version = api_version
+    entry.save
+  end
+
+  def generate_timestamp
+    self.accessed_at = DateTime.now
+  end
+end

--- a/db/migrate/20160817184931_add_document_access_time_log.rb
+++ b/db/migrate/20160817184931_add_document_access_time_log.rb
@@ -1,0 +1,9 @@
+class AddDocumentAccessTimeLog < ActiveRecord::Migration
+  create_table :document_access_log do |t|
+    t.integer :document_id
+    t.string :api_version
+    t.string :action
+    t.string :access_params
+    t.timestamp :accessed_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -64,6 +64,39 @@ ALTER SEQUENCE authentications_id_seq OWNED BY authentications.id;
 
 
 --
+-- Name: document_access_log; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE document_access_log (
+    id integer NOT NULL,
+    document_id integer,
+    api_version character varying(255),
+    action character varying(255),
+    access_params character varying(255),
+    accessed_at timestamp without time zone
+);
+
+
+--
+-- Name: document_access_log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE document_access_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: document_access_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE document_access_log_id_seq OWNED BY document_access_log.id;
+
+
+--
 -- Name: document_contents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -234,6 +267,13 @@ ALTER TABLE ONLY authentications ALTER COLUMN id SET DEFAULT nextval('authentica
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY document_access_log ALTER COLUMN id SET DEFAULT nextval('document_access_log_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY document_contents ALTER COLUMN id SET DEFAULT nextval('document_contents_id_seq'::regclass);
 
 
@@ -264,6 +304,14 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 ALTER TABLE ONLY authentications
     ADD CONSTRAINT authentications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: document_access_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY document_access_log
+    ADD CONSTRAINT document_access_log_pkey PRIMARY KEY (id);
 
 
 --
@@ -427,4 +475,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150205185407');
 INSERT INTO schema_migrations (version) VALUES ('20150224222201');
 
 INSERT INTO schema_migrations (version) VALUES ('20160816181715');
+
+INSERT INTO schema_migrations (version) VALUES ('20160817184931');
 


### PR DESCRIPTION
DO NOT MERGE - this branch is based on an unmerged branch (add-access-key-api)

Most of the changed code is to save the loaded document in the @document instance variable so that an after_filter can get the document information.  The new code is in the document_access_log model which logs the document id, the api version, the action (the controller action) and the access parameters used to load the document.