### PR TITLE
Add create document endpoint to v2 api [#128444429]

### DIFF
--- a/API.md
+++ b/API.md
@@ -42,7 +42,7 @@ The second version of the API is handled by the documents_v2 controller and expo
 
 - PATCH /v2/documents/:id - updates the contents of a document specified by id using the JSON Patch specification.  This requires the document's read-write access keys.
 
-- POST /v2/documents?title=<title>&[shared=(true|false)]&[source=<id>] - either creates a new document using the raw post content or creates a copy of a document identified by the source query parameter.  By default the newly created document does not have the sharing bit set but that can be set by passing ```shared=true``` as a parameter.  If the source parameter is passed it must be a shared document or else the copy with fail.  No access key is needed.  If a document is created this returns a 201 status code with the following json response:  ```{status: "[Created|Copied]", valid: true, id: <document.id>, readAccessKey: <document.read_access_key>, readWriteAccessKey: <document.read_write_access_key>}```.
+- POST /v2/documents?[shared=(true|false)]&[source=<id>] - either creates a new document using the raw post content or creates a copy of a document identified by the source query parameter.  By default the newly created document does not have the sharing bit set but that can be set by passing ```shared=true``` as a parameter.  If the source parameter is passed it must be a shared document or else the copy with fail.  No access key is needed.  If a document is created this returns a 201 status code with the following json response:  ```{status: "[Created|Copied]", valid: true, id: <document.id>, readAccessKey: <document.read_access_key>, readWriteAccessKey: <document.read_write_access_key>}```.
 
 ### Version 2 Access keys
 

--- a/API.md
+++ b/API.md
@@ -42,7 +42,7 @@ The second version of the API is handled by the documents_v2 controller and expo
 
 - PATCH /v2/documents/:id - updates the contents of a document specified by id using the JSON Patch specification.  This requires the document's read-write access keys.
 
-- POST /v2/documents - either creates a new anonymous shared document using the raw post content or creates a copy of a document identified by the source query parameter.  The source document must be a shared document or else the copy with fail.  No access key is needed.  If a document is created this returns a 201 status code with the following json response:  ```{status: "[Created|Copied]", valid: true, id: <document.id>, readAccessKey: <document.read_access_key>, readWriteAccessKey: <document.read_write_access_key>}```.
+- POST /v2/documents?title=<title>&[shared=(true|false)]&[source=<id>] - either creates a new document using the raw post content or creates a copy of a document identified by the source query parameter.  By default the newly created document does not have the sharing bit set but that can be set by passing ```shared=true``` as a parameter.  If the source parameter is passed it must be a shared document or else the copy with fail.  No access key is needed.  If a document is created this returns a 201 status code with the following json response:  ```{status: "[Created|Copied]", valid: true, id: <document.id>, readAccessKey: <document.read_access_key>, readWriteAccessKey: <document.read_write_access_key>}```.
 
 ### Version 2 Access keys
 

--- a/API.md
+++ b/API.md
@@ -36,13 +36,13 @@ And a CODAP specific API that was also used for the initial version of the [Clou
 
 The second version of the API is handled by the documents_v2 controller and exposes only a non-GUI programmatic API in the /v2/ namespace as:
 
-- GET /v2/documents/:id - returns the contents of a document specified by id.  This requires either the document's read-only or read-write access keys.
+- GET /v2/documents/:id - returns the contents of a document specified by id.  If the document is not shared this requires either the document's read-only or read-write access keys.
 
 - PUT /v2/documents/:id - updates the contents of a document specified by id.  This requires the document's read-write access keys.
 
 - PATCH /v2/documents/:id - updates the contents of a document specified by id using the JSON Patch specification.  This requires the document's read-write access keys.
 
-- POST /v2/documents - creates a copy of a document identified by the source query parameter and returns the new id of the document along with its read-only and read-write access keys.  The source document must be a shared document or else the copy with fail.  No access key is needed.
+- POST /v2/documents - either creates a new anonymous shared document using the raw post content or creates a copy of a document identified by the source query parameter.  The source document must be a shared document or else the copy with fail.  No access key is needed.  If a document is created this returns a 201 status code with the following json response:  ```{status: "[Created|Copied]", valid: true, id: <document.id>, readAccessKey: <document.read_access_key>, readWriteAccessKey: <document.read_write_access_key>}```.
 
 ### Version 2 Access keys
 

--- a/app/controllers/documents_v2_controller.rb
+++ b/app/controllers/documents_v2_controller.rb
@@ -76,7 +76,6 @@ class DocumentsV2Controller < ApplicationController
       copy_shared(new_doc_is_shared)
     else
       @document = Document.new
-      @document.title = params[:title]
       @document.form_content = request.raw_post
       @document.original_content = @document.content
       @document.shared = new_doc_is_shared

--- a/app/controllers/documents_v2_controller.rb
+++ b/app/controllers/documents_v2_controller.rb
@@ -128,7 +128,6 @@ class DocumentsV2Controller < ApplicationController
     end
     document.read_access_key = read_access_key
     document.read_write_access_key = read_write_access_key
-    document.run_key = read_write_access_key  # the run_key needs to be set because of the title validation: "validates :title, uniqueness: {scope: [:owner, :run_key]}"
   end
 
   def render_missing_param(param)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -9,7 +9,7 @@ class Document < ActiveRecord::Base
 
   scope :shared, -> { where(shared: true) }
 
-  validates :title, uniqueness: {scope: [:owner, :run_key]}
+  validates :title, uniqueness: {scope: [:owner, :run_key]}, if: :has_owner?
   validate :validate_form_content
 
   after_save :sync_attributes
@@ -61,6 +61,10 @@ class Document < ActiveRecord::Base
   def destroy_parent
     return unless @saved_parent
     @saved_parent.destroy unless @saved_parent.destroyed?
+  end
+
+  def has_owner?
+    self.owner != nil
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   get 'v2/documents/:id' => 'documents_v2#open'
   put 'v2/documents/:id' => 'documents_v2#save'
   patch 'v2/documents/:id' => 'documents_v2#patch'
-  post 'v2/documents' => 'documents_v2#copy_shared'
+  post 'v2/documents' => 'documents_v2#create'
 
   root :to => "home#index"
   devise_for :users, :controllers => {:registrations => "registrations", :omniauth_callbacks => "omniauth_callbacks"}

--- a/spec/features/documents/v2_api_spec.rb
+++ b/spec/features/documents/v2_api_spec.rb
@@ -167,7 +167,7 @@ feature 'Document', :codap do
         expect(doc.read_access_key).not_to be_nil
         expect(doc.read_write_access_key).not_to be_nil
         expect(doc.read_access_key).not_to eq doc.read_write_access_key
-        expect(doc.run_key).to eq doc.read_write_access_key
+        expect(doc.run_key).to eq nil
         expect(doc.shared).to eq false
       end
       scenario 'shared documents can be created' do
@@ -177,6 +177,17 @@ feature 'Document', :codap do
         response = JSON.parse(page.body)
         doc = Document.find(response["id"])
         expect(doc.shared).to eq true
+      end
+      scenario '(anonymous) documents with the same title can be created' do
+        page.driver.browser.submit :post, "/v2/documents?title=test", '{ "foo": "bar" }'
+        expect(page.status_code).to eq(201)
+        expect(page).to have_content %!{"status":"Created","valid":true,!
+        doc1_response = JSON.parse(page.body)
+        page.driver.browser.submit :post, "/v2/documents?title=test", '{ "foo": "bar" }'
+        expect(page.status_code).to eq(201)
+        expect(page).to have_content %!{"status":"Created","valid":true,!
+        doc2_response = JSON.parse(page.body)
+        expect(doc1_response["id"]).not_to eq doc2_response["id"]
       end
       scenario 'documents with no data cannot be created' do
         page.driver.browser.submit :post, "/v2/documents?title=test", ''
@@ -204,7 +215,7 @@ feature 'Document', :codap do
         expect(copy.original_content).to eq doc.content
         expect(copy.read_access_key).to eq response["readAccessKey"]
         expect(copy.read_write_access_key).to eq response["readWriteAccessKey"]
-        expect(copy.run_key).to eq response["readWriteAccessKey"]
+        expect(copy.run_key).to eq nil
         expect(copy.shared).to eq false
       end
 

--- a/spec/features/documents/v2_api_spec.rb
+++ b/spec/features/documents/v2_api_spec.rb
@@ -156,12 +156,11 @@ feature 'Document', :codap do
 
     describe 'create' do
       scenario 'unshared documents can be created' do
-        page.driver.browser.submit :post, "/v2/documents?title=test", '{ "foo": "bar" }'
+        page.driver.browser.submit :post, "/v2/documents", '{ "foo": "bar" }'
         expect(page.status_code).to eq(201)
         expect(page).to have_content %!{"status":"Created","valid":true,!
         response = JSON.parse(page.body)
         doc = Document.find(response["id"])
-        expect(doc.title).to eq "test"
         expect(doc.original_content.to_json).to eq '{"foo":"bar"}'
         expect(doc.original_content.to_json).to eq '{"foo":"bar"}'
         expect(doc.read_access_key).not_to be_nil
@@ -171,31 +170,20 @@ feature 'Document', :codap do
         expect(doc.shared).to eq false
       end
       scenario 'shared documents can be created' do
-        page.driver.browser.submit :post, "/v2/documents?title=test&shared=true", '{ "foo": "bar" }'
+        page.driver.browser.submit :post, "/v2/documents?shared=true", '{ "foo": "bar" }'
         expect(page.status_code).to eq(201)
         expect(page).to have_content %!{"status":"Created","valid":true,!
         response = JSON.parse(page.body)
         doc = Document.find(response["id"])
         expect(doc.shared).to eq true
       end
-      scenario '(anonymous) documents with the same title can be created' do
-        page.driver.browser.submit :post, "/v2/documents?title=test", '{ "foo": "bar" }'
-        expect(page.status_code).to eq(201)
-        expect(page).to have_content %!{"status":"Created","valid":true,!
-        doc1_response = JSON.parse(page.body)
-        page.driver.browser.submit :post, "/v2/documents?title=test", '{ "foo": "bar" }'
-        expect(page.status_code).to eq(201)
-        expect(page).to have_content %!{"status":"Created","valid":true,!
-        doc2_response = JSON.parse(page.body)
-        expect(doc1_response["id"]).not_to eq doc2_response["id"]
-      end
       scenario 'documents with no data cannot be created' do
-        page.driver.browser.submit :post, "/v2/documents?title=test", ''
+        page.driver.browser.submit :post, "/v2/documents", ''
         expect(page.status_code).to eq(400)
         expect(page).to have_content %!{"status":"Error","errors":["Form content must be valid json"],"valid":false,"message":"error.writeFailed"}!
       end
       scenario 'documents with invalid json cannot be created' do
-        page.driver.browser.submit :post, "/v2/documents?title=test", '{"foo'
+        page.driver.browser.submit :post, "/v2/documents", '{"foo'
         expect(page.status_code).to eq(400)
         expect(page).to have_content %!{"status":"Error","errors":["Form content must be valid json"],"valid":false,"message":"error.writeFailed"}!
       end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Document, :type => :model do
   describe "content handling" do
+
+    before(:each) { @user = User.new(email: 'user@example.com'); @user.save }
+
     it "should convert form_content string object into content hash" do
-      d = Document.new(title: "Doc", owner_id: 1)
+      d = Document.new(title: "Doc", owner: @user)
       d.form_content = '{ "test": "value", "bar": 1, "baz": { "sub": false }, "biz": [1,2,3,4]  }'
       expect(d.save).to be true
       expect(d.instance_variable_get("@form_content")).to be_nil
@@ -12,7 +15,7 @@ RSpec.describe Document, :type => :model do
     end
 
     it "should fail to save when form_content is invalid json" do
-      d = Document.new(title: "Doc", owner_id: 1)
+      d = Document.new(title: "Doc", owner: @user)
       d.form_content = '{ test: "value", "bar": 1, "baz": { "sub": false }, "biz": [1,2,3,4]  }'
       expect(d.save).to be false
       expect(d.instance_variable_get("@form_content")).not_to be_nil
@@ -20,21 +23,21 @@ RSpec.describe Document, :type => :model do
     end
 
     it 'should allow the document title to be re-used only when the run_key is different' do
-      d = Document.new(title: "Doc1", owner_id: 1, run_key: 'foo', form_content: '{ "test": "value" }')
+      d = Document.new(title: "Doc1", owner: @user, run_key: 'foo', form_content: '{ "test": "value" }')
       expect(d.save).to be true
 
-      d = Document.new(title: "Doc1", owner_id: 1, run_key: 'bar', form_content: '{ "test": "value" }')
+      d = Document.new(title: "Doc1", owner: @user, run_key: 'bar', form_content: '{ "test": "value" }')
       expect(d.save).to be true
 
-      d = Document.new(title: "Doc1", owner_id: 1, run_key: 'foo', form_content: '{ "test": "value" }')
+      d = Document.new(title: "Doc1", owner: @user, run_key: 'foo', form_content: '{ "test": "value" }')
       expect(d.save).to be false
 
-      # and work with anonymous docs
+      # anonymous docs can share titles
       d = Document.new(title: "Doc2", owner_id: nil, run_key: 'foo', form_content: '{ "test": "value" }')
       expect(d.save).to be true
 
       d = Document.new(title: "Doc2", owner_id: nil, run_key: 'foo', form_content: '{ "test": "value" }')
-      expect(d.save).to be false
+      expect(d.save).to be true
 
       d = Document.new(title: "Doc2", owner_id: nil, run_key: 'bar', form_content: '{ "test": "value" }')
       expect(d.save).to be true


### PR DESCRIPTION
Also update API documentation to note that no access key is required on a GET if the document is already shared.