### PR TITLE
Fix patch saving not working in LARA with v2 document store

### DIFF
--- a/lib/rack/inflate_request.rb
+++ b/lib/rack/inflate_request.rb
@@ -11,7 +11,7 @@ module Rack
     end
 
     def method_handled?(env)
-      !!(env['REQUEST_METHOD'] =~ /(POST|PUT)/)
+      !!(env['REQUEST_METHOD'] =~ /(POST|PUT|PATCH)/)
     end
 
     def encoding_handled?(env)


### PR DESCRIPTION
The v2 patch api call uses the PATCH verb which isn't handled by the document store inflater middleware.