### PR TITLE
Fix docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,4 @@ ENV BUNDLE_JOBS 2
 ENV BUNDLE_PATH /bundle
 ENV RAILS_ENV development
 
-EXPOSE 3001
-
-CMD rails s -b 0.0.0.0 -p 3001
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 FROM ruby:2.1.2
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential postgresql-client libpq-dev nodejs
+
 ENV APP_HOME /myapp
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
 # use a mounted volume so the gems don't need to be rebundled each time
-ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
-  BUNDLE_JOBS=2 \
-  BUNDLE_PATH=/bundle
+ENV BUNDLE_GEMFILE $APP_HOME/Gemfile
+ENV BUNDLE_JOBS 2
+ENV BUNDLE_PATH /bundle
+ENV RAILS_ENV development
 
-ENV RAILS_ENV=development
+EXPOSE 3001
 
-EXPOSE 3000
+CMD rails s -b 0.0.0.0 -p 3001

--- a/README.md
+++ b/README.md
@@ -47,18 +47,15 @@ Setting up a Portal authentication provider
 Docker
 ------
 
-A first pass at Docker support for this app is available.
-This is not currently working to run the app itself.
-But it is working well enough to update gems for example.
-`docker-compose run web bundle install`
+Run the command: `docker-compose up`
 
-In theory you should be able to run the app by:
-copying the config/database.yml.docker to config/database.yml
-Then create the database `docker-compose run web bundle exec rake db:create`
-Finally start the server with running `docker-compose up`
+Document server should be available at:
 
-However currently it seems to start, but it is not accessible when going to
-http://localhost:3000
+http://localhost:3001
+
+Other useful tips can be found at:
+
+https://github.com/concord-consortium/rigse/blob/master/docs/docker.md
 
 Acknowledgements
 ----------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,24 @@
 version: '3'
 services:
-  db:
-    image: postgres
   web:
-    build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    build:
+      context: .
+    command: ./docker-run.sh
     volumes:
       - .:/myapp:delegated
       - bundle:/bundle
     ports:
-      - "3000:3000"
+      - "3001:3001"
+    links:
+      - db
     depends_on:
       - db
+  db:
+    image: postgres:9.3
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 volumes:
   bundle:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,13 @@ services:
       - .:/myapp:delegated
       - bundle:/bundle
     ports:
-      - "3001:3001"
-    links:
-      - db
+      - "3001:3000"
     depends_on:
       - db
+    environment:
+      # V2_LINK_PROTOCOL sets protocol when you use local instance of document server and try to open it in LARA.
+      # Docker configuration uses unicorn and HTTP, so set this env variable to HTTP too.
+      V2_LINK_PROTOCOL: http
   db:
     image: postgres:9.3
     ports:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -23,9 +23,9 @@ if [ "$1" == "migrate-only" ]; then
   bundle exec rake db:create
   bundle exec rake db:migrate
 elif [ "$1" == "rails-only" ]; then
-  bundle exec unicorn -p 3001 -c ./config/unicorn.rb
+  bundle exec unicorn -p 3000 -c ./config/unicorn.rb
 else
   bundle exec rake db:create
   bundle exec rake db:migrate
-  bundle exec unicorn -p 3001 -c ./config/unicorn.rb
+  bundle exec unicorn -p 3000 -c ./config/unicorn.rb
 fi

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script is intended to be run inside of a development Docker container.
+
+DB_CONFIG=$APP_HOME/config/database.yml
+PIDFILE=$APP_HOME/tmp/pids/server.pid
+
+if [ -f $PIDFILE ]; then
+  rm $PIDFILE
+fi
+
+if [ ! -f $DB_CONFIG ]; then
+  cp $APP_HOME/config/database.yml.docker $DB_CONFIG
+fi
+
+bundle check || bundle install
+
+if [ "$RAILS_ENV" = "production" ]; then
+  bundle exec rake assets:precompile
+fi
+
+if [ "$1" == "migrate-only" ]; then
+  bundle exec rake db:create
+  bundle exec rake db:migrate
+elif [ "$1" == "rails-only" ]; then
+  bundle exec unicorn -p 3001 -c ./config/unicorn.rb
+else
+  bundle exec rake db:create
+  bundle exec rake db:migrate
+  bundle exec unicorn -p 3001 -c ./config/unicorn.rb
+fi


### PR DESCRIPTION
The main reason for the empty response from localhost:3000 was probably an incorrect way of staring server. I fixed all the other issues I saw, but it still didn't help, so I checked how the server was started on heroku and used the same method (`bundle exec unicorn -p 3001 -c ./config/unicorn.rb` instead of typical `rails s`). Other changes:
- postgres 9.3 (since heroku uses 9.3 too)
- postgres-client added to the web container
- changed def port to 3001 so it doesn't conflict with LARA
- db config slightly improved
- added docker-run.sh, similar to the one used in LARA so some chores are automated