### PR TITLE
Show dialog with interactive previews when more recent data is detected

### DIFF
--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -57,8 +57,8 @@ function autolaunchInteractive (documentId, launchUrl) {
     $('#state1-activity-name').text(state1.activityName);
     $('#state2-activity-name').text(state2.activityName);
 
-    var src1 = (state1.data || state1.interactiveState).lara_options.reporting_url;
-    var src2 = (state2.data || state2.interactiveState).lara_options.reporting_url;
+    var src1 = state1.interactiveState.lara_options.reporting_url;
+    var src2 = state2.interactiveState.lara_options.reporting_url;
     if (window.location.origin !== "https://document-store.concord.org") {
       // document-server, CFM or CODAP aren't very good in making sure that correct URLs are being used.
       // Even if you create a document pointing to some other instance of document-server, it gets lost
@@ -104,7 +104,7 @@ function autolaunchInteractive (documentId, launchUrl) {
   }
 
   function launchInteractive () {
-    var linkedState = mostRecentLinkedState && mostRecentLinkedState.data;
+    var linkedState = mostRecentLinkedState && mostRecentLinkedState.interactiveState;
     var launchParams = {url: interactiveData.interactiveStateUrl, source: documentId, collaboratorUrls: interactiveData.collaboratorUrls};
 
     // If there is a linked state and no interactive state then change the source document to point to the linked recordid and add the access key.
@@ -171,7 +171,7 @@ function autolaunchInteractive (documentId, launchUrl) {
     // Find linked state which is directly linked to this one. In fact it's a state which is the closest to given one
     // if there are some "gaps".
     directlyLinkedState = linkedStates && linkedStates.filter(function (el) {
-      return stateValid(el.data);
+      return stateValid(el.interactiveState);
     })[0];
     // Find the most recent linked state.
     mostRecentLinkedState = linkedStates && linkedStates.slice().sort(function (a, b) {
@@ -180,8 +180,8 @@ function autolaunchInteractive (documentId, launchUrl) {
 
     // There are a few possible cases now:
     var currentDataTimestamp = interactiveStateAvailable && new Date(interactiveData.updatedAt);
-    var mostRecentLinkedStateTimestamp = stateValid(mostRecentLinkedState && mostRecentLinkedState.data) && new Date(mostRecentLinkedState.updatedAt);
-    var directlyLinkedStateTimestamp = stateValid(directlyLinkedState && directlyLinkedState.data) && new Date(directlyLinkedState.updatedAt);
+    var mostRecentLinkedStateTimestamp = stateValid(mostRecentLinkedState && mostRecentLinkedState.interactiveState) && new Date(mostRecentLinkedState.updatedAt);
+    var directlyLinkedStateTimestamp = stateValid(directlyLinkedState && directlyLinkedState.interactiveState) && new Date(directlyLinkedState.updatedAt);
 
     // Current state is available, but there's most recent data in one of the linked states. Ask user.
     if (interactiveStateAvailable && mostRecentLinkedStateTimestamp && mostRecentLinkedStateTimestamp > currentDataTimestamp) {

--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -1,0 +1,154 @@
+function autolaunchInteractive (documentId, launchUrl) {
+
+  // Update the loading message after 10 seconds
+  var showTimeoutId = setTimeout(function() {
+    $('#loading-text').html("Still loading!  You may want to reload this page to try again.")
+  }, 10000);
+
+  var phone = iframePhone.getIFrameEndpoint();
+  // Variables below are set in `initInteractive` handler.
+  var interactiveData = null;
+  var mostRecentLinkedState = null;
+  var interactiveStateAvailable = false;
+
+  function stateValid (state) {
+    return state && state.docStore && state.docStore.recordid && state.docStore.accessKeys && state.docStore.accessKeys.readOnly;
+  }
+
+  function showDataSelectDialog () {
+    function showPreview (element) {
+      $(element).addClass('preview-active');
+      $('.overlay').show();
+    }
+    function hidePreview () {
+      $('.preview-active').removeClass('preview-active');
+      $('.overlay').hide();
+    }
+
+    $('.data-select-dialog').show()
+    $('#prev-version-time').text((new Date(mostRecentLinkedState.updatedAt)).toLocaleString())
+    $('#current-version-time').text((new Date(interactiveData.interactiveStateUpdatedAt)).toLocaleString())
+
+    var currentUrl = interactiveData.interactiveStateUrl;
+    var srcCurrent = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify({ url: currentUrl }))});
+    $('#current-version-preview').attr('src', srcCurrent);
+
+    var prevUrl = mostRecentLinkedState.interactiveStateUrl;
+    var srcPrev = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify({ url: prevUrl }))});
+    $('#prev-version-preview').attr('src', srcPrev)
+
+    $('.overlay').on('click', hidePreview);
+    $('.preview').on('click', function () {
+      if ($(this).hasClass('preview-active')) {
+        hidePreview();
+      } else {
+        showPreview(this);
+      }
+    });
+    $('.preview-label').on('click', function () {
+      showPreview($(this).closest('.version-info').find('.preview')[0]);
+    });
+    $('#prev-version-button').on('click', function () {
+      // Remove existing interactive state, so the interactive will be initialized from the linked state.
+      phone.post('interactiveState', null);
+      interactiveStateAvailable = false;
+      launchInteractive();
+      $('.data-select-dialog').remove();
+    });
+    $('#current-version-button').on('click', function () {
+      // Update current state timestamp, so it will be considered to be the most recent one.
+      phone.post('interactiveState', 'touch');
+      mostRecentLinkedState = null;
+      launchInteractive();
+      $('.data-select-dialog').remove();
+    });
+  }
+
+  function launchInteractive () {
+    var linkedState = mostRecentLinkedState && mostRecentLinkedState.data;
+    var launchParams = {url: interactiveData.interactiveStateUrl, source: documentId, collaboratorUrls: interactiveData.collaboratorUrls};
+
+    // If there is a linked state and no interactive state then change the source document to point to the linked recordid and add the access key.
+    if (stateValid(linkedState) && !interactiveStateAvailable) {
+      launchParams.source = linkedState.docStore.recordid;
+      launchParams.readOnlyKey = linkedState.docStore.accessKeys.readOnly;
+    }
+    // Interactive state saves are supported by autolaunch currently only when the app iframed by autolaunch uses
+    // the Cloud File Manager (CFM).  The CFM in the iframed app handles all the state saving -- Lara only receives
+    // 'nochange' or 'touch' as the state. 'touch' notifies LARA that state has been updated.
+    //
+    // 1. Autolaunch informs Lara that interactive state is supported using the supportedFeatures message
+    // 2. Once the iframed app loads autolaunch sends a cfm::getCommands message to the iframed app and sets a
+    //    iframeCanAutosave flag when a cfm::commands is received from the iframed app and the app supports cfm::autosave
+    // 3. When autolaunch gets an getInteractiveState request from Lara it either
+    //    a. immedatiely returns 'nochange' to Lara when the iframeCanAutosave flag isn't set
+    //    b. sends a 'cfm::autosave' message to the app and then sends 'nochange' when the app returns 'cfm::autosaved'
+
+    phone.post('supportedFeatures', {
+      apiVersion: 1,
+      features: {
+        interactiveState: true
+      }
+    });
+
+    var iframeCanAutosave = false;
+    var iframeLoaded = function () {
+      $(window).on('message', function (e) {
+        var data = e.originalEvent.data
+        if (data) {
+          switch (data.type) {
+            case 'cfm::commands':
+              iframeCanAutosave = data.commands && data.commands.indexOf('cfm::autosave') !== -1;
+              break;
+            case 'cfm::autosaved':
+              phone.post('interactiveState', data.saved ? 'touch' : 'nochange');
+              break;
+          }
+        }
+      })
+      iframe.postMessage({type: 'cfm::getCommands'}, '*')
+    };
+
+    phone.addListener('getInteractiveState', function () {
+      if (iframeCanAutosave) {
+        iframe.postMessage({type: 'cfm::autosave'}, '*');
+      }
+      else {
+        phone.post('interactiveState', 'nochange');
+      }
+    });
+
+    var src = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify(launchParams))});
+    var iframe = $("#autolaunch_iframe").on('load', iframeLoaded).attr("src", src).show()[0].contentWindow;
+  }
+
+  phone.addListener('initInteractive', function (_interactiveData) {
+    clearTimeout(showTimeoutId);
+
+    interactiveData = _interactiveData;
+    interactiveStateAvailable = stateValid(interactiveData.interactiveState);
+    // Use most recent linked state.
+    var linkedStates = interactiveData.allLinkedStates;
+    mostRecentLinkedState = linkedStates && linkedStates.slice().sort(function (a, b) {
+      return new Date(b.updatedAt) - new Date(a.updatedAt)
+    })[0];
+    var linkedStateTimestamp = stateValid(mostRecentLinkedState && mostRecentLinkedState.data) && new Date(mostRecentLinkedState.updatedAt);
+    var currentDataTimestamp = interactiveStateAvailable && new Date(interactiveData.interactiveStateUpdatedAt);
+
+    if (linkedStateTimestamp && currentDataTimestamp && linkedStateTimestamp > currentDataTimestamp) {
+      showDataSelectDialog();
+    } else {
+      launchInteractive();
+    }
+  });
+
+  phone.addListener('getExtendedSupport', function() {
+    phone.post('extendedSupport', { reset: false });
+  });
+
+  // TODO: there seems to be a race condition between when the page loads and when initialize can be called
+  setTimeout(function () {
+    // Initialize connection after all message listeners are added!
+    phone.initialize();
+  }, 1000);
+}

--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -1,4 +1,6 @@
 function autolaunchInteractive (documentId, launchUrl) {
+  var CURRENT_VS_LINKED = "Another page contains more recent data. Which would you like to use?";
+  var LINKED_VS_LINKED = "There are two possibilities for continuing your work. Which version would you like to use?";
 
   // Update the loading message after 10 seconds
   var showTimeoutId = setTimeout(function() {
@@ -25,9 +27,25 @@ function autolaunchInteractive (documentId, launchUrl) {
       $('.overlay').hide();
     }
 
+    if (interactiveStateAvailable) {
+      $('#question').text(CURRENT_VS_LINKED);
+    } else {
+      $('#question').text(LINKED_VS_LINKED);
+    }
+
     $('.data-select-dialog').show()
-    $('#prev-version-time').text((new Date(mostRecentLinkedState.updatedAt)).toLocaleString())
-    $('#current-version-time').text((new Date(interactiveData.interactiveStateUpdatedAt)).toLocaleString())
+    $('#prev-version-time').text((new Date(mostRecentLinkedState.updatedAt)).toLocaleString());
+    $('#current-version-time').text((new Date(interactiveData.interactiveStateUpdatedAt)).toLocaleString());
+    $('#prev-version-page-idx').text(mostRecentLinkedState.pageIndex);
+    $('#current-version-page-idx').text(interactiveData.pageIndex);
+    if (mostRecentLinkedState.pageName) {
+      $('#prev-version-page-name').text(' - ' + mostRecentLinkedState.pageName);
+    }
+    if (interactiveData.pageName) {
+      $('#current-version-page-name').text(' - ' + interactiveData.pageName);
+    }
+    $('#prev-version-activity-name').text(mostRecentLinkedState.activityName);
+    $('#current-version-activity-name').text(interactiveData.activityName);
 
     var currentUrl = interactiveData.interactiveStateUrl;
     var srcCurrent = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify({ url: currentUrl }))});

--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -46,8 +46,8 @@ function autolaunchInteractive (documentId, launchUrl) {
     $('.data-select-dialog').show()
     $('#state1-time').text((new Date(state1.updatedAt)).toLocaleString());
     $('#state2-time').text((new Date(state2.updatedAt)).toLocaleString());
-    $('#state1-page-idx').text(state1.pageIndex);
-    $('#state2-page-idx').text(state2.pageIndex);
+    $('#state1-page-idx').text(state1.pageNumber);
+    $('#state2-page-idx').text(state2.pageNumber);
     if (state1.pageName) {
       $('#state1-page-name').text(' - ' + state1.pageName);
     }
@@ -57,13 +57,18 @@ function autolaunchInteractive (documentId, launchUrl) {
     $('#state1-activity-name').text(state1.activityName);
     $('#state2-activity-name').text(state2.activityName);
 
-    var prevUrl = state1.interactiveStateUrl;
-    var srcPrev = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify({ url: prevUrl }))});
-    $('#state1-preview').attr('src', srcPrev)
-
-    var currentUrl = state2.interactiveStateUrl;
-    var srcCurrent = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify({ url: currentUrl }))});
-    $('#state2-preview').attr('src', srcCurrent);
+    var src1 = (state1.data || state1.interactiveState).lara_options.reporting_url;
+    var src2 = (state2.data || state2.interactiveState).lara_options.reporting_url;
+    if (window.location.origin !== "https://document-store.concord.org") {
+      // document-server, CFM or CODAP aren't very good in making sure that correct URLs are being used.
+      // Even if you create a document pointing to some other instance of document-server, it gets lost
+      // somewhere and CODAP/CFM will try to use the default one. This little hack lets you test things
+      // locally or with a custom document server deployment.
+      src1 += "&documentServer=" + window.location.origin;
+      src2 += "&documentServer=" + window.location.origin;
+    }
+    $('#state1-preview').attr('src', src1);
+    $('#state2-preview').attr('src', src2);
 
     $('.overlay').on('click', hidePreview);
     $('.preview').on('click', function () {
@@ -197,7 +202,7 @@ function autolaunchInteractive (documentId, launchUrl) {
     // state is the most recent one.
     if (!interactiveStateAvailable && directlyLinkedState) {
       // Show "Copying work from..." message when it actually happens and keep it visible for 3 seconds.
-      $('#copy-page-idx').text(directlyLinkedState.pageIndex);
+      $('#copy-page-idx').text(directlyLinkedState.pageNumber);
       if (directlyLinkedState.pageName) {
         $('#copy-page-name').text(' - ' + directlyLinkedState.pageName);
       }

--- a/app/assets/stylesheets/autolaunch.scss
+++ b/app/assets/stylesheets/autolaunch.scss
@@ -9,6 +9,10 @@
   display: none;
 }
 
+.center {
+  text-align: center;
+}
+
 .data-select-dialog {
   display: none;
   position: absolute;
@@ -156,8 +160,39 @@
     transform-origin: left top;
     border: solid 1px;
   }
+}
 
-  .center {
-    text-align: center;
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #b6e2eb;
+  padding-top: 50px;
+
+  table {
+    width: 600px;
+    margin: 0 auto;
+    border: none;
+
+    td {
+      padding: 5px;
+      font-size: 15px;
+    }
+    th {
+      width: 100px;
+      font-weight: normal;
+    }
   }
+
+  .loading-text {
+    font-size: 21px;
+    vertical-align: middle;
+    color: #555;
+  }
+}
+
+#copy-overlay {
+  display: none;
 }

--- a/app/assets/stylesheets/autolaunch.scss
+++ b/app/assets/stylesheets/autolaunch.scss
@@ -1,0 +1,135 @@
+#autolaunch_iframe {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: none;
+}
+
+.data-select-dialog {
+  display: none;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  
+  .header {
+    background: #214d5a;
+    width: 100%;
+    color: white;
+    font-size: 1.5em;
+    padding: 5px;
+    text-align: center;
+  }
+
+  .content {
+    background: white;
+    margin-top: 8px;
+    padding: 10px;
+    font-size: 18px;
+    color: #666;
+    overflow: auto;
+  }
+
+  .question {
+    padding: 5px 25px;
+  }
+
+  .versions {
+    text-align: center;
+  }
+
+  .version-info {
+    display: inline-block;
+    width: 400px;
+    margin: 20px 10px;
+  }
+
+  .dialog-button {
+    background: #82bec8;
+    border-radius: 5px;
+    text-align: center;
+    padding: 6px 10px;
+    margin: 10px;
+    width: auto;
+    display: inline-block;
+    color: white;
+    cursor: pointer;
+    &:hover {
+      background: #679aa1;
+    }
+  }
+
+  .iframe-wrapper {
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .preview {
+    width: 400px;
+    height: 300px;
+    cursor: pointer;
+    &:hover {
+      box-shadow: 2px 2px 4px #aaa;
+    }
+  }
+
+  .preview-label {
+    font-size: 16px;
+    padding: 5px;
+    cursor: pointer;
+    &:hover {
+      color: #333;
+    }
+  }
+
+  .preview-active {
+    position: fixed;
+    top: 40px;
+    left: 3%;
+    width: 94%;
+    height: 90%;
+    z-index: 100;
+    cursor: pointer;
+    iframe {
+      width: 100%;
+      height: 100%;
+      transform: scale3d(1, 1, 1);
+    }
+  }
+
+  .overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 90;
+    background: #6ca0a9;
+    padding-top: 10px;
+    font-size: 20px;
+    color: white;
+    text-align: center;
+    cursor: pointer;
+  }
+
+  iframe {
+    width: 300%;
+    height: 300%;
+    transform: scale3d(0.333333, 0.333333, 1);
+    transform-origin: left top;
+    border: solid 1px;
+  }
+
+  .center {
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/autolaunch.scss
+++ b/app/assets/stylesheets/autolaunch.scss
@@ -117,10 +117,19 @@
     height: 90%;
     z-index: 100;
     cursor: pointer;
-    iframe {
-      width: 100%;
-      height: 100%;
-      transform: scale3d(1, 1, 1);
+    @media (max-width: 1200px) {
+      iframe {
+        width: 150%;
+        height: 150%;
+        transform: scale3d(0.666666, 0.666666, 1);
+      }
+    }
+    @media (min-width: 1200px) {
+      iframe {
+        width: 100%;
+        height: 100%;
+        transform: scale3d(1, 1, 1);
+      }
     }
   }
 

--- a/app/assets/stylesheets/autolaunch.scss
+++ b/app/assets/stylesheets/autolaunch.scss
@@ -37,8 +37,9 @@
     overflow: auto;
   }
 
-  .question {
+  #question {
     padding: 5px 25px;
+    text-align: center;
   }
 
   .versions {
@@ -49,6 +50,24 @@
     display: inline-block;
     width: 400px;
     margin: 20px 10px;
+  }
+
+  table.version-desc {
+    width: 100%;
+    border: none;
+
+    td {
+      padding: 5px;
+      font-size: 14px;
+    }
+    th {
+      width: 100px;
+      font-weight: normal;
+    }
+  }
+
+  .prop {
+    font-weight: bold;
   }
 
   .dialog-button {
@@ -82,7 +101,7 @@
   }
 
   .preview-label {
-    font-size: 16px;
+    font-size: 14px;
     padding: 5px;
     cursor: pointer;
     &:hover {

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -61,14 +61,3 @@ pre code {
   font-size: 0.8em;
   color: #408187;
 }
-
-#autolaunch_iframe {
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: none;
-}

--- a/app/views/documents_v2/autolaunch.html.haml
+++ b/app/views/documents_v2/autolaunch.html.haml
@@ -12,6 +12,45 @@
             Loading...
     %iframe#autolaunch_iframe
 
+    .data-select-dialog
+      .overlay
+        This is read-only preview of your data. Click anywhere to close it.
+
+      .header
+        WHAT WOULD YOU LIKE TO DO?
+      .content
+        .question
+          A previous version contains more recent data. Would you like to use this version instead?
+
+        .versions
+          .version-info
+            Previous version -
+            %span#prev-version-time
+
+            .center
+              #prev-version-button.dialog-button
+                Use this version
+
+            .preview
+              .iframe-wrapper
+                %iframe#prev-version-preview
+            .center.preview-label
+              Click to preview
+
+          .version-info
+            Current version -
+            %span#current-version-time
+
+            .center
+              #current-version-button.dialog-button
+                Use this version
+
+            .preview
+              .iframe-wrapper
+                %iframe#current-version-preview
+            .center.preview-label
+              Click to preview
+
   -else
     .row
       .small-12.text-center.columns{style: "color: #990000" }
@@ -24,109 +63,5 @@
 -if @document && @document.shared
   :javascript
     $(document).ready(function() {
-      // Update the loading message after 10 seconds
-      var showTimeoutId = setTimeout(function() {
-        $('#loading-text').html("Still loading!  You may want to reload this page to try again.")
-      }, 10000);
-
-      var phone = iframePhone.getIFrameEndpoint();
-      var interactiveRunState, interactiveStateUrl;
-
-      phone.addListener('initInteractive', function (interactiveData) {
-        var launchParams = {url: interactiveData.interactiveStateUrl, source: #{@document.id}, collaboratorUrls: interactiveData.collaboratorUrls};
-        var launchUrl = #{@launch_url.to_json};
-
-        clearTimeout(showTimeoutId);
-
-        interactiveRunState = interactiveData.interactiveState || {};
-        interactiveStateUrl = interactiveData.interactiveStateUrl;
-
-        var interactiveStateAvailable = interactiveRunState && interactiveRunState.docStore && interactiveRunState.docStore.recordid
-        // Use most recent linked state.
-        var linkedStateMetadata = interactiveData.allLinkedStates.slice().sort(function (a, b) {
-          return new Date(b.updatedAt) - new Date(a.updatedAt)
-        })[0];
-        var linkedState = linkedStateMetadata && linkedStateMetadata.data ? linkedStateMetadata.data : null;
-
-        if (linkedState && new Date(linkedStateMetadata.updatedAt) > new Date(interactiveData.interactiveStateUpdatedAt)) {
-          var shouldUseMostRecent = window.confirm(
-            "A previous version contains more recent data. " +
-            "Would you like to use this version instead?\n" +
-            "Previous version: " + new Date(linkedStateMetadata.updatedAt).toLocaleString() + "\n" +
-            "Current version: " + new Date(interactiveData.interactiveStateUpdatedAt).toLocaleString()
-          )
-          if (shouldUseMostRecent) {
-            // Remove existing interactive state, so the interactive will be initialized from the linked state.
-            phone.post('interactiveState', null);
-            interactiveStateAvailable = false;
-          } else {
-            // Update current state timestamp, so it will be considered to be the most recent one.
-            phone.post('interactiveState', 'touch');
-          }
-        }
-
-        // if there is a linked state and no interactive state then change the source document to point to the linked recordid and add the access key
-        if (linkedState && linkedState.docStore && linkedState.docStore.recordid && linkedState.docStore.accessKeys && linkedState.docStore.accessKeys.readOnly && !interactiveStateAvailable) {
-          launchParams.source = linkedState.docStore.recordid;
-          launchParams.readOnlyKey = linkedState.docStore.accessKeys.readOnly;
-        }
-
-        // Interactive state saves are supported by autolaunch currently only when the app iframed by autolaunch uses
-        // the Cloud File Manager (CFM).  The CFM in the iframed app handles all the state saving -- Lara only ever
-        // receives 'nochange' as the state.
-        //
-        // 1. Autolaunch informs Lara that interactive state is supported using the supportedFeatures message
-        // 2. Once the iframed app loads autolaunch sends a cfm::getCommands message to the iframed app and sets a
-        //    iframeCanAutosave flag when a cfm::commands is received from the iframed app and the app supports cfm::autosave
-        // 3. When autolaunch gets an getInteractiveState request from Lara it either
-        //    a. immedatiely returns 'nochange' to Lara when the iframeCanAutosave flag isn't set
-        //    b. sends a 'cfm::autosave' message to the app and then sends 'nochange' when the app returns 'cfm::autosaved'
-
-        phone.post('supportedFeatures', {
-          apiVersion: 1,
-          features: {
-            interactiveState: true
-          }
-        });
-
-        var iframeCanAutosave = false;
-        var iframeLoaded = function () {
-          $(window).on('message', function (e) {
-            var data = e.originalEvent.data
-            if (data) {
-              switch (data.type) {
-                case 'cfm::commands':
-                  iframeCanAutosave = data.commands && data.commands.indexOf('cfm::autosave') !== -1;
-                  break;
-                case 'cfm::autosaved':
-                  phone.post('interactiveState', data.saved ? 'touch' : 'nochange');
-                  break;
-              }
-            }
-          })
-          iframe.postMessage({type: 'cfm::getCommands'}, '*')
-        };
-
-        phone.addListener('getInteractiveState', function () {
-          if (iframeCanAutosave) {
-            iframe.postMessage({type: 'cfm::autosave'}, '*');
-          }
-          else {
-            phone.post('interactiveState', 'nochange');
-          }
-        });
-
-        var src = $.param.querystring(launchUrl, {launchFromLara: Base64.encode(JSON.stringify(launchParams))});
-        var iframe = $("#autolaunch_iframe").on('load', iframeLoaded).attr("src", src).show()[0].contentWindow;
-      });
-
-      phone.addListener('getExtendedSupport', function() {
-        phone.post('extendedSupport', { reset: false });
-      });
-
-      // TODO: there seems to be a race condition between when the page loads and when initialize can be called
-      setTimeout(function () {
-        // Initialize connection after all message listeners are added!
-        phone.initialize();
-      }, 1000);
+      autolaunchInteractive(#{@document.id}, #{@launch_url.to_json})
     });

--- a/app/views/documents_v2/autolaunch.html.haml
+++ b/app/views/documents_v2/autolaunch.html.haml
@@ -3,14 +3,28 @@
     There was a problem setting up this interactive. Please try refreshing your page.
 -if @document
   - if @document.shared
-    .row
-      .small-12.text-center.columns.end
-        #loading-message
-          %span#loading-image
-            =image_tag "loading.gif"
-          %span#loading-text
-            Loading...
+    .loading-overlay
+      .center
+        =image_tag "loading.gif"
+        %span.loading-text
+          Loading interactive...
+
     %iframe#autolaunch_iframe
+
+    .loading-overlay#copy-overlay
+      .center
+        =image_tag "loading.gif"
+        %span.loading-text
+          Copying work from...
+        %table
+          %tr
+            %th Page
+            %td
+              %span#copy-page-idx
+              %span#copy-page-name
+          %tr
+            %th Activity
+            %td#copy-activity-name
 
     .data-select-dialog
       .overlay

--- a/app/views/documents_v2/autolaunch.html.haml
+++ b/app/views/documents_v2/autolaunch.html.haml
@@ -19,17 +19,12 @@
       .header
         WHAT WOULD YOU LIKE TO DO?
       .content
-        .question
-          A previous version contains more recent data. Would you like to use this version instead?
+        #question
 
         .versions
           .version-info
-            Previous version -
-            %span#prev-version-time
-
-            .center
-              #prev-version-button.dialog-button
-                Use this version
+            #prev-version-button.dialog-button
+              Use this version
 
             .preview
               .iframe-wrapper
@@ -37,10 +32,20 @@
             .center.preview-label
               Click to preview
 
-          .version-info
-            Current version -
-            %span#current-version-time
+            %table.version-desc
+              %tr
+                %th Updated at
+                %td#prev-version-time
+              %tr
+                %th Page
+                %td
+                  %span#prev-version-page-idx
+                  %span#prev-version-page-name
+              %tr
+                %th Activity
+                %td#prev-version-activity-name
 
+          .version-info
             .center
               #current-version-button.dialog-button
                 Use this version
@@ -50,6 +55,19 @@
                 %iframe#current-version-preview
             .center.preview-label
               Click to preview
+
+            %table.version-desc
+              %tr
+                %th Updated at
+                %td#current-version-time
+              %tr
+                %th Page
+                %td
+                  %span#current-version-page-idx
+                  %span#current-version-page-name
+              %tr
+                %th Activity
+                %td#current-version-activity-name
 
   -else
     .row

--- a/app/views/documents_v2/autolaunch.html.haml
+++ b/app/views/documents_v2/autolaunch.html.haml
@@ -23,51 +23,51 @@
 
         .versions
           .version-info
-            #prev-version-button.dialog-button
+            #state1-button.dialog-button
               Use this version
 
             .preview
               .iframe-wrapper
-                %iframe#prev-version-preview
+                %iframe#state1-preview
             .center.preview-label
               Click to preview
 
             %table.version-desc
               %tr
                 %th Updated at
-                %td#prev-version-time
+                %td#state1-time
               %tr
                 %th Page
                 %td
-                  %span#prev-version-page-idx
-                  %span#prev-version-page-name
+                  %span#state1-page-idx
+                  %span#state1-page-name
               %tr
                 %th Activity
-                %td#prev-version-activity-name
+                %td#state1-activity-name
 
           .version-info
             .center
-              #current-version-button.dialog-button
+              #state2-button.dialog-button
                 Use this version
 
             .preview
               .iframe-wrapper
-                %iframe#current-version-preview
+                %iframe#state2-preview
             .center.preview-label
               Click to preview
 
             %table.version-desc
               %tr
                 %th Updated at
-                %td#current-version-time
+                %td#state2-time
               %tr
                 %th Page
                 %td
-                  %span#current-version-page-idx
-                  %span#current-version-page-name
+                  %span#state2-page-idx
+                  %span#state2-page-name
               %tr
                 %th Activity
-                %td#current-version-activity-name
+                %td#state2-activity-name
 
   -else
     .row


### PR DESCRIPTION
I've reimplemented autolaunch page and added UI for selection of the most recent data based on provided mocks. I was considering adding React, but finally, I didn't do it. This UI isn't very complex and lives for a short time only (before user makes a selection), so I decided that the whole overhead of adding React, npm, making sure that Heroku deploys it correctly, etc., isn't worth it.

LARA changes are required for it to work: 
https://github.com/concord-consortium/lara/pull/280

I didn't try to make it backward compatible, so we'd need to deploy those changes together with LARA (let me know if it's a problem).
