### PR TITLE
Fix some edge cases while loading linked states

### DIFF
--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -167,12 +167,12 @@ function autolaunchInteractive (documentId, launchUrl) {
     interactiveData = _interactiveData;
     interactiveStateAvailable = stateValid(interactiveData.interactiveState);
 
-    var linkedStates = interactiveData.allLinkedStates;
+    var linkedStates = interactiveData.allLinkedStates && interactiveData.allLinkedStates.filter(function (el) {
+      return stateValid(el.interactiveState);
+    });
     // Find linked state which is directly linked to this one. In fact it's a state which is the closest to given one
     // if there are some "gaps".
-    directlyLinkedState = linkedStates && linkedStates.filter(function (el) {
-      return stateValid(el.interactiveState);
-    })[0];
+    directlyLinkedState = linkedStates && linkedStates[0];
     // Find the most recent linked state.
     mostRecentLinkedState = linkedStates && linkedStates.slice().sort(function (a, b) {
       return new Date(b.updatedAt) - new Date(a.updatedAt)


### PR DESCRIPTION
Failing test case:
https://authoring.staging.concord.org/sequences/207/activities/19861

- Go to page 1 and run interactive.
- Go to page 2, but do NOT run interactive (click to play feature).
- Go to page 3. It should copy data from page 1 (and it says so), but it doesn't seem to happen in reality.

This PR fixes it by considering only non-null / valid states.