### PR TITLE
Fullscreen help and "Undo my work" button support

### DIFF
--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -122,7 +122,7 @@ function autolaunchInteractive (documentId, launchUrl) {
       apiVersion: 1,
       features: {
         interactiveState: true,
-        reset: false
+        reset: true
       }
     };
     if (fullscreenScaling) {

--- a/app/assets/javascripts/fullscreen.js
+++ b/app/assets/javascripts/fullscreen.js
@@ -21,6 +21,8 @@ function fullscreenSupport (iframe) {
       $target.css('height', '100%');
       $target.css('transform', 'scale3d(1,1,1)');
     }
+    // Help text.
+    $('#fullscreen-help').css('fontSize', Math.round(Math.pow(window.innerWidth / 5, 0.65)) + 'px');
   }
 
   function setupFullsceenButton () {

--- a/app/assets/stylesheets/autolaunch.css.scss
+++ b/app/assets/stylesheets/autolaunch.css.scss
@@ -197,6 +197,25 @@
   display: none;
 }
 
+#fullscreen-help {
+  position: fixed;
+  left: 0;
+  bottom: 12px;
+  height: 40px;
+  width: calc(100% - 50px);
+  text-align: center;
+  line-height: 36px;
+  font-size: 0;
+  color: #8e8e8e;
+  text-shadow: 1px 1px 5px #fff;
+
+  &.hidden {
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 1.5s ease-out 2s, visibility .01s linear 3.5s;
+  }
+}
+
 .fullscreen-icon {
   display: none;
   font-size: 45px;

--- a/app/views/documents_v2/autolaunch.html.haml
+++ b/app/views/documents_v2/autolaunch.html.haml
@@ -11,6 +11,9 @@
 
     %iframe#autolaunch_iframe
 
+    #fullscreen-help
+      Click here to enter/exit fullscreen →
+
     .fullscreen-icon
 
     .loading-overlay#copy-overlay


### PR DESCRIPTION
Two unrelated changes, but I slightly refactored the common code in the first commit, so decided to keep those changes together.

1. New tooltip pointing fullscreen button:
    <img width="567" alt="screen shot 2018-03-26 at 14 34 58" src="https://user-images.githubusercontent.com/767857/37934390-e60fa7d6-3102-11e8-889c-6b41305f1996.png"> 
   It will disappear after a few seconds once user starts using CODAP (it waits for mouse enter event).

2. Autolaunch doesn't send `reset: false` anymore, so LARA displays "Undo my work" button.

