### PR TITLE
Prevent page navigation blocking in LARA when user looks at data selection dialog

### DIFF
--- a/app/assets/javascripts/autolaunch.js
+++ b/app/assets/javascripts/autolaunch.js
@@ -245,6 +245,14 @@ function autolaunchInteractive (documentId, launchUrl) {
 
   // TODO: there seems to be a race condition between when the page loads and when initialize can be called
   setTimeout(function () {
+    phone.addListener('getInteractiveState', function () {
+      // Temporary listener used only before CODAP document is loaded.
+      // It always return "nochange" response. If LARA establishes connection with iframe that saves state,
+      // it will block page navigation until it gets response for `getInteractiveState`. This handler ensures that
+      // a response will be always delivered, even if user is stuck at data selector dialog.
+      // When CODAP document is loaded, this listener will be overwritten.
+      phone.post('interactiveState', 'nochange');
+    });
     // Initialize connection after all message listeners are added!
     phone.initialize();
     sendSupportedFeaturesMsg();


### PR DESCRIPTION
[#155571787]

This PR fixes a bug found by @eireland:

> If you click on Return to activity from the What Would You Like To Do screen without selecting one of the pages, you can't navigate to another page in LARA.

I hope that the comment in the code explains issue and solution. Generally, LARA was blocking page navigation as it was waiting forever for `getInteractiveState` response. Handler wasn't already setup if user was still in data selection mode, before CODAP doc was loaded.