### PR TITLE
Hide fullscreen tooltip when fullscreen mode is not available

### DIFF
--- a/app/assets/javascripts/fullscreen.js
+++ b/app/assets/javascripts/fullscreen.js
@@ -26,6 +26,7 @@ function fullscreenSupport (iframe) {
   }
 
   function setupFullsceenButton () {
+    $('#fullscreen-help').show();
     var $button = $('.fullscreen-icon');
     $button.show();
     $button.on('click', function () {

--- a/app/assets/stylesheets/autolaunch.css.scss
+++ b/app/assets/stylesheets/autolaunch.css.scss
@@ -198,6 +198,7 @@
 }
 
 #fullscreen-help {
+  display: none;
   position: fixed;
   left: 0;
   bottom: 12px;


### PR DESCRIPTION
Hide fullscreen tooltip when the fullscreen mode is not available, e.g. on iOS devices.